### PR TITLE
REFACTOR - Renomeia classe Hospede e remove linhas extras

### DIFF
--- a/src/model/Hospede.java
+++ b/src/model/Hospede.java
@@ -1,14 +1,7 @@
-/*
- * Click nbfs://nbhost/SystemFileSystem/Templates/Licenses/license-default.txt to change this license
- * Click nbfs://nbhost/SystemFileSystem/Templates/Classes/Class.java to edit this template
- */
 package model;
 
-/**
- *
- * @author Luiz
- */
-public class Hospedes {
+public class Hospede {
+    
     private int id;
     private String nome;
     private String telefone;


### PR DESCRIPTION
Notei que o nome da classe Hospede estava no plural e isso estava dando erro com a classe Reserva, fiz essa alteração, e aproveitei para retirar algumas linhas que estavam "sobrando" no código.